### PR TITLE
Fix: add missing v6/xapi_v6.*lib

### DIFF
--- a/v6/xapi_v6.mldylib
+++ b/v6/xapi_v6.mldylib
@@ -1,0 +1,5 @@
+# OASIS_START
+# DO NOT EDIT (digest: ea6a705e628fece9d1850106f5dc5d63)
+V6_interface
+V6_client
+# OASIS_STOP

--- a/v6/xapi_v6.mllib
+++ b/v6/xapi_v6.mllib
@@ -1,0 +1,5 @@
+# OASIS_START
+# DO NOT EDIT (digest: ea6a705e628fece9d1850106f5dc5d63)
+V6_interface
+V6_client
+# OASIS_STOP


### PR DESCRIPTION
Add two files to fix the build.

Signed-off-by: Christian Lindig lindig@gmail.com
